### PR TITLE
Clarified manpages on how to add a new user

### DIFF
--- a/man/au.1.md
+++ b/man/au.1.md
@@ -39,7 +39,8 @@ server to perform the requested operation.
 **nu**
 
 :   New user. The **nu** option tells the **auth2** daemon to add a new
-    password entry to the Coda password database.
+    password entry to the Coda password database. Note that the user has
+    to be known to coda in beforehand. This is done via **pdbtool** *new user*.
 
 **cp**
 
@@ -65,6 +66,11 @@ BUGS
 ====
 
 **au** echos new passwords to the terminal as they are typed in.
+
+SEE ALSO
+========
+
+**pdbtool**(8)
 
 AUTHORS
 =======

--- a/man/pdbtool.8.md
+++ b/man/pdbtool.8.md
@@ -35,7 +35,7 @@ functionally required by some users. Has hard coded file locations. :)
 SEE ALSO
 ========
 
-**auth2**(8)
+**au**(1), **auth2**(8)
 
 AUTHORS
 =======


### PR DESCRIPTION
From reading the manpages I thought that 'au nu' would do the whole job of adding a new user.
It didn't.
So I dropped a line in the manpage for the next adventurer ;-)